### PR TITLE
fix: scoped rate limit counter

### DIFF
--- a/pkg/middlewares/ratelimiter/rate_limiter.go
+++ b/pkg/middlewares/ratelimiter/rate_limiter.go
@@ -146,7 +146,12 @@ func (rl *rateLimiter) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		logger.Info().Msgf("ignoring token bucket amount > 1: %d", amount)
 	}
 
-	delay, err := rl.limiter.Allow(ctx, source)
+	// Each rate limiter has its own source space,
+	// ensuring independence between rate limiters,
+	// i.e., rate limit rules are only applied based on traffic
+	// where the rate limiter is active.
+	rlSource := rl.name + ":" + source
+	delay, err := rl.limiter.Allow(ctx, rlSource)
 	if err != nil {
 		rl.logger.Error().Err(err).Msg("Could not insert/update bucket")
 		observability.SetStatusErrorf(ctx, "Could not insert/update bucket")


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Bug fixes:
- for Traefik v2: use branch v2.11
- for Traefik v3: use branch v3.3

Enhancements:
- for Traefik v2: we only accept bug fixes
- for Traefik v3: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

### What does this PR do?

Fix: adapt the rate limiter source key to also include the middleware name, ensuring that one middleware cannot affect another, regardless of the rate limit counter storage.

This interdependency between rate-limiting middlewares occurs with the Redis rate limiter when two middlewares use the same Redis connection parameters.
For a given source, both middlewares are updating the same Redis key.

### Motivation

While testing the new redis rate limiter solution coming in 3.4 (thank you, it's great, we've been waiting for it for a long time), it appears that one middleware configuration on a specific route was affecting another rate limit middleware on another route.

This was due to the fact that:

* both middlewares were using the same redis cluster
* the current rate limit "state by source" key is only based on the source name (`rate:10.172.0.3` for example), meaning two different ratelimit middlewares applied on two different routes will use the same "source state", one affecting the other.

Proposed solution: scope the rate limit "counters" key per `middleware + source` allowing to have independent rate limit computations based only on the traffic handled by each middleware whatever the storage solution is.

For the in memory rate limiter, the key is renamed from `<source>` to `<middleware name>:<source>`,
for the redis rate limiter, the redis key is renamed from `rate:<source>` to `rate:<middleware name>:<source>`.

